### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish Docker image to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.12
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BASEIMAGE: ${{ matrix.baseimage.image }}
           MINECRAFT_JAR: ${{ matrix.minecraft.jar }}.jar


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore